### PR TITLE
There's no point in unescaping data that is not string

### DIFF
--- a/misc/js/pushstream.js
+++ b/misc/js/pushstream.js
@@ -303,7 +303,7 @@
     var message = {
         id     : msg[keys.jsonIdKey],
         channel: msg[keys.jsonChannelKey],
-        data   : unescapeText(msg[keys.jsonDataKey]),
+        data   : (typeof (msg[keys.jsonDataKey]) == 'string') ? unescapeText(msg[keys.jsonDataKey]) : msg[keys.jsonDataKey], 
         tag    : msg[keys.jsonTagKey],
         time   : msg[keys.jsonTimeKey],
         eventid: msg[keys.jsonEventIdKey] || ""


### PR DESCRIPTION
In our project we're passing around JSON objects. We've got issuses with PushStream library because onmessage callback got broken data as argument - exactly string "[object Object]" - it's happening, because  parseMessage function initially converts message from JSON string (with our JSON data object inside) but then make it corrupted by unescaping it.

I've made little patch, unfortunately I wasn't been able to run test, because jshint gem is no longer available. But anyway, I didn't find any tests regarding parsing messages and I don't understand library architecture to write tests from scratch.

Best regards,
Karol Ciba
