### PR TITLE
Fix  for multipart domain suffix  (com.au) for Firefox

### DIFF
--- a/misc/js/pushstream.js
+++ b/misc/js/pushstream.js
@@ -262,7 +262,15 @@
 
   var extract_xss_domain = function(domain) {
     // if domain is a ip address return it, else return the last two parts of it
-    return (domain.match(/^(\d{1,3}\.){3}\d{1,3}$/)) ? domain : domain.split('.').slice(-2).join('.');
+    if ( (domain.match(/^(\d{1,3}\.){3}\d{1,3}$/)) ){
+        return  domain;
+    }
+    var domainParts = domain.split('.')
+    // window.domain="com.au" fails (illegal) on firefox we need to keep more than 2 parts in this case
+    // always keep 2 domain parts , if 3 provided cut to 2, if 4 cut to 3.
+    var keepNumber = Math.max(domainParts.length -1, 2);
+
+    return   domainParts.slice( -1 * keepNumber ).join('.');
   };
 
   var linker = function(method, instance) {


### PR DESCRIPTION
Hi Wandenberg,

If the  web client  is on a domain with multiple domain suffix  like : mydomain._com.au_, then nginx pushstream.js set document.domain to 'com.au'. Firefox throws "Error: Illegal document.domain value".

I applied the following logic :
1) document.domain should be at least 2 parts 
2) if 3, set the domain to the last 2.
3) if 4, se the domain to the last 3.  etc..

Hope you can find this pull request useful.

cheers

-sebastien
