### PR TITLE
Adding a GET method handler for publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+nbproject/
 .cproject
 .project
 .settings/

--- a/include/ngx_http_push_stream_module.h
+++ b/include/ngx_http_push_stream_module.h
@@ -72,6 +72,7 @@ typedef struct {
     ngx_int_t                       index_channels_path;
     ngx_uint_t                      authorized_channels_only;
     ngx_flag_t                      store_messages;
+    ngx_flag_t                      get_method_publishing;
     ngx_str_t                       header_template;
     ngx_str_t                       message_template;
     ngx_int_t                       message_template_index;

--- a/misc/nginx.conf
+++ b/misc/nginx.conf
@@ -83,6 +83,9 @@ http {
             # store messages in memory
             push_stream_store_messages              off;
 
+            # enable get method for publishing
+            push_stream_get_method_publishing       off;
+
             push_stream_keepalive                   on;
 
             # Message size limit

--- a/src/ngx_http_push_stream_module_publisher.c
+++ b/src/ngx_http_push_stream_module_publisher.c
@@ -27,11 +27,12 @@
 #include <ngx_http_push_stream_module_version.h>
 
 static ngx_int_t    ngx_http_push_stream_publisher_handle_post(ngx_http_push_stream_loc_conf_t *cf, ngx_http_request_t *r, ngx_str_t *id);
+static ngx_int_t    ngx_http_push_stream_publisher_handle_get(ngx_http_push_stream_loc_conf_t *cf, ngx_http_request_t *r, ngx_str_t *id);
 
 static ngx_int_t
 ngx_http_push_stream_publisher_handler(ngx_http_request_t *r)
 {
-    ngx_str_t                          *id = NULL;
+	ngx_str_t                          *id = NULL;
     ngx_http_push_stream_channel_t     *channel = NULL;
     ngx_http_push_stream_loc_conf_t    *cf = ngx_http_get_module_loc_conf(r, ngx_http_push_stream_module);
 
@@ -72,6 +73,11 @@ ngx_http_push_stream_publisher_handler(ngx_http_request_t *r)
 
     if (r->method == NGX_HTTP_POST) {
         return ngx_http_push_stream_publisher_handle_post(cf, r, id);
+    }
+
+	// Handle GET publish requests
+    if (r->method == NGX_HTTP_GET && cf->get_method_publishing) {
+        return ngx_http_push_stream_publisher_handle_get(cf, r, id);		
     }
 
     // GET or DELETE only make sense with a previous existing channel
@@ -127,6 +133,55 @@ ngx_http_push_stream_publisher_handle_post(ngx_http_push_stream_loc_conf_t *cf, 
     }
 
     return NGX_DONE;
+}
+
+static ngx_int_t
+ngx_http_push_stream_publisher_handle_get(ngx_http_push_stream_loc_conf_t *cf, ngx_http_request_t *r, ngx_str_t *id)
+{
+    ngx_str_t							*event_id = NULL, *event_type = NULL, *msg = NULL;
+    ngx_str_t							space_char = ngx_string(" ");
+	u_char								*dst, *src;
+	//int									len;
+	ngx_http_push_stream_channel_t		*channel = NULL;
+
+    // check if channel id isn't equals to ALL or contain wildcard
+    if ((ngx_memn2cmp(id->data, NGX_HTTP_PUSH_STREAM_ALL_CHANNELS_INFO_ID.data, id->len, NGX_HTTP_PUSH_STREAM_ALL_CHANNELS_INFO_ID.len) == 0) || (ngx_strchr(id->data, '*') != NULL)) {
+        return ngx_http_push_stream_send_only_header_response(r, NGX_HTTP_FORBIDDEN, &NGX_HTTP_PUSH_STREAM_NO_CHANNEL_ID_NOT_AUTHORIZED_MESSAGE);
+    }
+
+    // create the channel if doesn't exist
+    channel = ngx_http_push_stream_get_channel(id, r->connection->log, cf);
+    if (channel == NULL) {
+        ngx_log_error(NGX_LOG_ERR, (r)->connection->log, 0, "push stream module: unable to allocate memory for new channel");
+        return ngx_http_push_stream_send_only_header_response(r, NGX_HTTP_INTERNAL_SERVER_ERROR, NULL);
+    }
+
+    if (channel == NGX_HTTP_PUSH_STREAM_NUMBER_OF_CHANNELS_EXCEEDED) {
+        ngx_log_error(NGX_LOG_ERR, (r)->connection->log, 0, "push stream module: number of channels were exceeded");
+        return ngx_http_push_stream_send_only_header_response(r, NGX_HTTP_FORBIDDEN, &NGX_HTTP_PUSH_STREAM_NUMBER_OF_CHANNELS_EXCEEDED_MESSAGE);
+    }
+	
+    event_id = ngx_http_push_stream_get_header(r, &NGX_HTTP_PUSH_STREAM_HEADER_EVENT_ID);
+	event_type = ngx_http_push_stream_get_header(r, &NGX_HTTP_PUSH_STREAM_HEADER_EVENT_TYPE);
+	
+	// get the query string (instead of request body for POST)
+	if ((msg = ngx_http_push_stream_create_str(r->pool, r->args.len)) == NULL) {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "push stream module: unable to allocate memory for string $msg (in handle_get)");
+        return NGX_ERROR;
+	}
+	dst = ngx_cpymem(msg->data, r->args.data, r->args.len);
+
+	// decode the query string before using it
+	dst = msg->data;
+	src = msg->data;
+
+	ngx_unescape_uri(&dst, &src, msg->len, NGX_UNESCAPE_URI);
+	msg->len = dst - msg->data;
+	
+	// add the message to the channel
+	ngx_http_push_stream_add_msg_to_channel(r, id, msg->data, msg->len, event_id, event_type, r->pool);
+
+	return ngx_http_push_stream_send_response(r, &space_char, &cf->content_type, NGX_HTTP_OK);
 }
 
 static void

--- a/src/ngx_http_push_stream_module_publisher.c
+++ b/src/ngx_http_push_stream_module_publisher.c
@@ -32,7 +32,7 @@ static ngx_int_t    ngx_http_push_stream_publisher_handle_get(ngx_http_push_stre
 static ngx_int_t
 ngx_http_push_stream_publisher_handler(ngx_http_request_t *r)
 {
-	ngx_str_t                          *id = NULL;
+    ngx_str_t                          *id = NULL;
     ngx_http_push_stream_channel_t     *channel = NULL;
     ngx_http_push_stream_loc_conf_t    *cf = ngx_http_get_module_loc_conf(r, ngx_http_push_stream_module);
 
@@ -75,9 +75,9 @@ ngx_http_push_stream_publisher_handler(ngx_http_request_t *r)
         return ngx_http_push_stream_publisher_handle_post(cf, r, id);
     }
 
-	// Handle GET publish requests
+    // Handle GET publish requests
     if (r->method == NGX_HTTP_GET && cf->get_method_publishing) {
-        return ngx_http_push_stream_publisher_handle_get(cf, r, id);		
+        return ngx_http_push_stream_publisher_handle_get(cf, r, id);        
     }
 
     // GET or DELETE only make sense with a previous existing channel
@@ -138,11 +138,11 @@ ngx_http_push_stream_publisher_handle_post(ngx_http_push_stream_loc_conf_t *cf, 
 static ngx_int_t
 ngx_http_push_stream_publisher_handle_get(ngx_http_push_stream_loc_conf_t *cf, ngx_http_request_t *r, ngx_str_t *id)
 {
-    ngx_str_t							*event_id = NULL, *event_type = NULL, *msg = NULL;
-    ngx_str_t							space_char = ngx_string(" ");
-	u_char								*dst, *src;
-	//int									len;
-	ngx_http_push_stream_channel_t		*channel = NULL;
+    ngx_str_t                           *event_id = NULL, *event_type = NULL, *msg = NULL;
+    ngx_str_t                           space_char = ngx_string(" ");
+    u_char                              *dst, *src;
+    //int                                   len;
+    ngx_http_push_stream_channel_t      *channel = NULL;
 
     // check if channel id isn't equals to ALL or contain wildcard
     if ((ngx_memn2cmp(id->data, NGX_HTTP_PUSH_STREAM_ALL_CHANNELS_INFO_ID.data, id->len, NGX_HTTP_PUSH_STREAM_ALL_CHANNELS_INFO_ID.len) == 0) || (ngx_strchr(id->data, '*') != NULL)) {
@@ -160,28 +160,28 @@ ngx_http_push_stream_publisher_handle_get(ngx_http_push_stream_loc_conf_t *cf, n
         ngx_log_error(NGX_LOG_ERR, (r)->connection->log, 0, "push stream module: number of channels were exceeded");
         return ngx_http_push_stream_send_only_header_response(r, NGX_HTTP_FORBIDDEN, &NGX_HTTP_PUSH_STREAM_NUMBER_OF_CHANNELS_EXCEEDED_MESSAGE);
     }
-	
+    
     event_id = ngx_http_push_stream_get_header(r, &NGX_HTTP_PUSH_STREAM_HEADER_EVENT_ID);
-	event_type = ngx_http_push_stream_get_header(r, &NGX_HTTP_PUSH_STREAM_HEADER_EVENT_TYPE);
-	
-	// get the query string (instead of request body for POST)
-	if ((msg = ngx_http_push_stream_create_str(r->pool, r->args.len)) == NULL) {
+    event_type = ngx_http_push_stream_get_header(r, &NGX_HTTP_PUSH_STREAM_HEADER_EVENT_TYPE);
+    
+    // get the query string (instead of request body for POST)
+    if ((msg = ngx_http_push_stream_create_str(r->pool, r->args.len)) == NULL) {
         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "push stream module: unable to allocate memory for string $msg (in handle_get)");
         return NGX_ERROR;
-	}
-	dst = ngx_cpymem(msg->data, r->args.data, r->args.len);
+    }
+    dst = ngx_cpymem(msg->data, r->args.data, r->args.len);
 
-	// decode the query string before using it
-	dst = msg->data;
-	src = msg->data;
+    // decode the query string before using it
+    dst = msg->data;
+    src = msg->data;
 
-	ngx_unescape_uri(&dst, &src, msg->len, NGX_UNESCAPE_URI);
-	msg->len = dst - msg->data;
-	
-	// add the message to the channel
-	ngx_http_push_stream_add_msg_to_channel(r, id, msg->data, msg->len, event_id, event_type, r->pool);
+    ngx_unescape_uri(&dst, &src, msg->len, NGX_UNESCAPE_URI);
+    msg->len = dst - msg->data;
+    
+    // add the message to the channel
+    ngx_http_push_stream_add_msg_to_channel(r, id, msg->data, msg->len, event_id, event_type, r->pool);
 
-	return ngx_http_push_stream_send_response(r, &space_char, &cf->content_type, NGX_HTTP_OK);
+    return ngx_http_push_stream_send_response(r, &space_char, &cf->content_type, NGX_HTTP_OK);
 }
 
 static void

--- a/src/ngx_http_push_stream_module_setup.c
+++ b/src/ngx_http_push_stream_module_setup.c
@@ -134,6 +134,12 @@ static ngx_command_t    ngx_http_push_stream_commands[] = {
         NGX_HTTP_LOC_CONF_OFFSET,
         offsetof(ngx_http_push_stream_loc_conf_t, store_messages),
         NULL },
+    { ngx_string("push_stream_get_method_publishing"),
+        NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+        ngx_conf_set_flag_slot,
+        NGX_HTTP_LOC_CONF_OFFSET,
+        offsetof(ngx_http_push_stream_loc_conf_t, get_method_publishing),
+        NULL },
     { ngx_string("push_stream_channel_info_on_publish"),
         NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
         ngx_conf_set_flag_slot,
@@ -538,6 +544,7 @@ ngx_http_push_stream_create_loc_conf(ngx_conf_t *cf)
 
     lcf->authorized_channels_only = NGX_CONF_UNSET_UINT;
     lcf->store_messages = NGX_CONF_UNSET_UINT;
+    lcf->get_method_publishing = NGX_CONF_UNSET_UINT;
     lcf->message_template_index = -1;
     lcf->message_template.data = NULL;
     lcf->header_template.data = NULL;
@@ -570,6 +577,7 @@ ngx_http_push_stream_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 
     ngx_conf_merge_uint_value(conf->authorized_channels_only, prev->authorized_channels_only, 0);
     ngx_conf_merge_value(conf->store_messages, prev->store_messages, 0);
+    ngx_conf_merge_value(conf->get_method_publishing, prev->get_method_publishing, 0);
     ngx_conf_merge_str_value(conf->header_template, prev->header_template, NGX_HTTP_PUSH_STREAM_DEFAULT_HEADER_TEMPLATE);
     ngx_conf_merge_str_value(conf->message_template, prev->message_template, NGX_HTTP_PUSH_STREAM_DEFAULT_MESSAGE_TEMPLATE);
     ngx_conf_merge_str_value(conf->footer_template, prev->footer_template, NGX_HTTP_PUSH_STREAM_DEFAULT_FOOTER_TEMPLATE);


### PR DESCRIPTION
In some cases it might be needed that publishing could be done only with a GET request and adding a GET handler for publishing would be useful. 
It takes the whole query string as data parameter (instead of request body in case of POST).

Please let us know if you also think this would be a useful feature.

Regards,
Nikolay