### PR TITLE
Update pushstream.js for correct work with IE9

### DIFF
--- a/misc/js/pushstream.js
+++ b/misc/js/pushstream.js
@@ -244,7 +244,10 @@
       if (settings.beforeSend) { settings.beforeSend(xhr); }
 
       var onerror = function() {
-        try { xhr.abort(); } catch (e) { /* ignore error on closing */ }
+        try { 
+          xhr.onreadystatechange = undefined;
+          xhr.abort(); 
+        } catch (e) { /* ignore error on closing */ }
         Ajax.clear(settings);
         settings.error(304);
       };
@@ -721,7 +724,7 @@
         this.xhrSettings.data = extend({}, this.pushstream.extraParams(), this.xhrSettings.data, getControlParams(this.pushstream));
         if (this.useJSONP) {
           this.connection = Ajax.jsonp(this.xhrSettings);
-        } else if (!this.connection) {
+        } else {
           this.connection = Ajax.load(this.xhrSettings);
         }
       }


### PR DESCRIPTION
IE9 causes error when you trying to read xhr props after xhr.abort(). So, we must remove onreadystatechange of xhr to prevent this errors. Also, LongPollingWrapper#_internalListen method was fixed: we must send new response after abort of previous xhr.
