### PR TITLE
Add --raw flag to curl example

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -68,9 +68,9 @@ one terminal and start playing http pubsub:
 
 <pre>
     # Subs
-    curl -s -v 'http://localhost/sub/my_channel_1'
-    curl -s -v 'http://localhost/sub/your_channel_1'
-    curl -s -v 'http://localhost/sub/your_channel_2'
+    curl --raw -s -v 'http://localhost/sub/my_channel_1'
+    curl --raw -s -v 'http://localhost/sub/your_channel_1'
+    curl --raw -s -v 'http://localhost/sub/your_channel_2'
 
     # Pubs
     curl -s -v -X POST 'http://localhost/pub?id=my_channel_1' -d 'Hello World!'


### PR DESCRIPTION
The curl example to subscribe to a channel wont show the published messages b/c curl buffers responses. It's expected behavior of curl, however, it's a bit confusing when first trying to get the example running. The only evidence I have of this is my own anecdotal experience and somebody who ran into the same problem in issue #137 