### PR TITLE
Update pushstream.js

### DIFF
--- a/misc/js/pushstream.js
+++ b/misc/js/pushstream.js
@@ -564,7 +564,7 @@ Authors: Wandenberg Peixoto <wandenberg@gmail.com>, Rogério Carvalho Schneider 
 
     disconnect: function() {
       if (this.connection) {
-        Log4js.debug("[WebSocket] closing connection to:", this.connection.URL);
+        Log4js.debug("[WebSocket] closing connection to:", this.connection.url);
         this.connection.onclose = null;
         this._closeCurrentConnection();
         this.pushstream._onclose();
@@ -606,7 +606,7 @@ Authors: Wandenberg Peixoto <wandenberg@gmail.com>, Rogério Carvalho Schneider 
 
     disconnect: function() {
       if (this.connection) {
-        Log4js.debug("[EventSource] closing connection to:", this.connection.URL);
+        Log4js.debug("[EventSource] closing connection to:", this.connection.url);
         this.connection.onclose = null;
         this._closeCurrentConnection();
         this.pushstream._onclose();


### PR DESCRIPTION
Since chrome updated to version 38 it states 'WebSocket.URL' is deprecated. Please use 'WebSocket.url' instead.