### PR TITLE
Send event time to onmessage callback

### DIFF
--- a/docs/javascript_client.textile
+++ b/docs/javascript_client.textile
@@ -83,4 +83,4 @@ Example:
 | onerror | implement this function to be notified when an error happens, the argument received is an object with a key named 'type' indicating if was a 'load' or a 'timeout' error |
 | onstatuschange | implement this function to receive the new connection status as argument, which can be PushStream.CLOSED, PushStream.CONNECTING or PushStream.OPEN |
 | onchanneldeleted | implement this function to be notified when a channel was deleted on the server. The channel id will be the given argument|
-| onmessage | implement this function to receive the messages from server, the arguments are, in order: text, id, channel, eventid, isLastMessageFromBatch. The isLastMessageFromBatch argument indicate when is, or not, the last message received on a batch when using long polling connections |
+| onmessage | implement this function to receive the messages from server, the arguments are, in order: text, id, channel, eventid, isLastMessageFromBatch, time. The isLastMessageFromBatch argument indicate when is, or not, the last message received on a batch when using long polling connections |

--- a/misc/js/pushstream.js
+++ b/misc/js/pushstream.js
@@ -517,7 +517,7 @@ Authors: Wandenberg Peixoto <wandenberg@gmail.com>, Rogério Carvalho Schneider 
     if (message.tag) { this.pushstream._etag = message.tag; }
     if (message.time) { this.pushstream._lastModified = message.time; }
     if (message.eventid) { this.pushstream._lastEventId = message.eventid; }
-    this.pushstream._onmessage(message.text, message.id, message.channel, message.eventid, true);
+    this.pushstream._onmessage(message.text, message.id, message.channel, message.eventid, true, message.time);
   };
 
   var onopenCallback = function() {
@@ -725,7 +725,7 @@ Authors: Wandenberg Peixoto <wandenberg@gmail.com>, Rogério Carvalho Schneider 
         if (time) { this.pushstream._lastModified = time; }
         if (eventid) { this.pushstream._lastEventId = eventid; }
       }
-      this.pushstream._onmessage(unescapeText(text), id, channel, eventid || "", true);
+      this.pushstream._onmessage(unescapeText(text), id, channel, eventid || "", true, time);
       this.setPingTimer();
     },
 
@@ -866,7 +866,7 @@ Authors: Wandenberg Peixoto <wandenberg@gmail.com>, Rogério Carvalho Schneider 
 
       while (this.messagesQueue.length > 0) {
         var message = this.messagesQueue.shift();
-        this.pushstream._onmessage(message.text, message.id, message.channel, message.eventid, (this.messagesQueue.length === 0));
+        this.pushstream._onmessage(message.text, message.id, message.channel, message.eventid, (this.messagesQueue.length === 0), message.time);
       }
     }
   };
@@ -1080,12 +1080,12 @@ Authors: Wandenberg Peixoto <wandenberg@gmail.com>, Rogério Carvalho Schneider 
       this._reconnect(this.reconnectOnTimeoutInterval);
     },
 
-    _onmessage: function(text, id, channel, eventid, isLastMessageFromBatch) {
-      Log4js.debug("message", text, id, channel, eventid, isLastMessageFromBatch);
+    _onmessage: function(text, id, channel, eventid, isLastMessageFromBatch, time) {
+      Log4js.debug("message", text, id, channel, eventid, isLastMessageFromBatch, time);
       if (id === -2) {
         if (this.onchanneldeleted) { this.onchanneldeleted(channel); }
       } else if (id > 0) {
-        if (this.onmessage) { this.onmessage(text, id, channel, eventid, isLastMessageFromBatch); }
+        if (this.onmessage) { this.onmessage(text, id, channel, eventid, isLastMessageFromBatch, time); }
       }
     },
 


### PR DESCRIPTION
In some cases, pleople might need the time of the event in their application. In most cases, `(new Date()).getTime()` will do the job, but when you load a stored messages, this is not usable anymore. 
This change sends event time on onmessage callback as 6th parameter (after `isLastMessageFromBatch`).

The event time is sent in GMT timezone.

The scenario for which i had to do this change:
I use pushstream for a realtime dashboard, and i aggregate events per second, and per minute. because I load data since 4 hours ago, i needed the time of the event so i can aggregate history properly.