### PR TITLE
Replace < with equivalent html entity

### DIFF
--- a/misc/js/pushstream.js
+++ b/misc/js/pushstream.js
@@ -683,7 +683,7 @@ Authors: Wandenberg Peixoto <wandenberg@gmail.com>, Rogério Carvalho Schneider 
       if ("ActiveXObject" in window) {
         var transferDoc = new window.ActiveXObject("htmlfile");
         transferDoc.open();
-        transferDoc.write("<html><script>document.domain='" + document.domain + "';</script><body><iframe id='" + this.iframeId + "' src='" + url + "'></iframe></body></html>");
+        transferDoc.write("<html><script>document.domain='" + document.domain + "';\x3C/script><body><iframe id='" + this.iframeId + "' src='" + url + "'></iframe></body></html>");
         transferDoc.parentWindow.PushStream = PushStream;
         transferDoc.close();
         ifr = transferDoc.getElementById(this.iframeId);


### PR DESCRIPTION
This will prevent the script from breaking since `</script` makes browsers think that this is the end of the whole script, thus rendering anything after the script closing tag as plain HTML instead.