### PR TITLE
Let Nginx choose effective polling method

### DIFF
--- a/misc/nginx.conf
+++ b/misc/nginx.conf
@@ -16,7 +16,6 @@ worker_processes    2;
 
 events {
     worker_connections  1024;
-    use                 poll;
 }
 
 http {


### PR DESCRIPTION
There is no point to downgrade to poll is O(n). Polling method epoll O(1) is selected automatically for Linux or kqueue for BSD