### PR TITLE
Extend messagesPublishedAfter with Callback

### DIFF
--- a/misc/js/pushstream.js
+++ b/misc/js/pushstream.js
@@ -1030,9 +1030,9 @@ Authors: Wandenberg Peixoto <wandenberg@gmail.com>, Rogério Carvalho Schneider 
         this._lastEventId = this.lastEventId;
       }
       if (this._lastModified === null) {
-        var date = this.messagesPublishedAfter;
+        var date = (typeof this.messagesPublishedAfter === 'function') ? this.messagesPublishedAfter() : this.messagesPublishedAfter;
         if (!isDate(date)) {
-          var messagesPublishedAfter = Number(this.messagesPublishedAfter);
+          var messagesPublishedAfter = Number(date);
           if (messagesPublishedAfter > 0) {
             date = new Date();
             date.setTime(date.getTime() - (messagesPublishedAfter * 1000));


### PR DESCRIPTION
You can initialize messagesPublishedAfter with a callback function or with a number like till now.

Just return the amounts of seconds in the function. So you are able to calculate the value in a dynamic way (e.g. offset since last message).

For example:
```
new PushStream({
      messagesPublishedAfter: function() {return 60}
}
```