### PR TITLE
Reconnect without timeout

### DIFF
--- a/misc/js/pushstream.js
+++ b/misc/js/pushstream.js
@@ -888,8 +888,8 @@ Authors: Wandenberg Peixoto <wandenberg@gmail.com>, Rogério Carvalho Schneider 
 
     this.timeout = settings.timeout || 30000;
     this.pingtimeout = settings.pingtimeout || 30000;
-    this.reconnectOnTimeoutInterval = settings.reconnectOnTimeoutInterval || 3000;
-    this.reconnectOnChannelUnavailableInterval = settings.reconnectOnChannelUnavailableInterval || 60000;
+    this.reconnectOnTimeoutInterval = settings.hasOwnProperty('reconnectOnTimeoutInterval') ? settings.reconnectOnTimeoutInterval : 3000;
+    this.reconnectOnChannelUnavailableInterval = settings.hasOwnProperty('reconnectOnChannelUnavailableInterval') ? settings.reconnectOnChannelUnavailableInterval : 60000;
     this.autoReconnect = (settings.autoReconnect !== false);
 
     this.lastEventId = settings.lastEventId || null;


### PR DESCRIPTION
I don't need reconnect with timeout, bun i can't set zero to the suitable settings parameters, because ```settings.reconnectOnTimeoutInterval || 3000``` returns 3000, when settings.reconnectOnTimeoutInterval is zero.