### PR TITLE
pushstream.js: remove handling of the 'unload' event

### DIFF
--- a/misc/js/pushstream.js
+++ b/misc/js/pushstream.js
@@ -1127,18 +1127,9 @@ Authors: Wandenberg Peixoto <wandenberg@gmail.com>, Rogério Carvalho Schneider 
     }
   };
 
-  PushStream.unload = function() {
-    for (var i = 0; i < PushStreamManager.length; i++) {
-      try { PushStreamManager[i].disconnect(); } catch(e){}
-    }
-  };
-
   /* make class public */
   window.PushStream = PushStream;
   window.PushStreamManager = PushStreamManager;
   if (window.jasmine) { window.Utils = Utils; }
-
-  if (window.attachEvent) { window.attachEvent("onunload", PushStream.unload); }
-  if (window.addEventListener) { window.addEventListener.call(window, "unload", PushStream.unload, false); }
 
 })(window, document);


### PR DESCRIPTION
The 'unload' event is deprecated by browsers.
https://developer.mozilla.org/en-US/docs/Web/API/Window/unload_event
The handler is closing connections, which the browser will do anyway, automatically.