### PR TITLE
Found vulnerability in ngx_http_push_stream_complex_value

### DIFF
--- a/include/ngx_http_push_stream_module_utils.h
+++ b/include/ngx_http_push_stream_module_utils.h
@@ -259,7 +259,7 @@ static ngx_int_t            ngx_http_push_stream_memory_cleanup(void);
 
 ngx_chain_t *               ngx_http_push_stream_get_buf(ngx_http_request_t *r);
 static void                 ngx_http_push_stream_unescape_uri(ngx_str_t *value);
-static void                 ngx_http_push_stream_complex_value(ngx_http_request_t *r, ngx_http_complex_value_t *val, ngx_str_t *value);
+static ngx_int_t            ngx_http_push_stream_complex_value(ngx_http_request_t *r, ngx_http_complex_value_t *val, ngx_str_t *value);
 
 
 ngx_int_t                   ngx_http_push_stream_add_msg_to_channel(ngx_http_push_stream_main_conf_t *mcf, ngx_log_t *log, ngx_http_push_stream_channel_t *channel, u_char *text, size_t len, ngx_str_t *event_id, ngx_str_t *event_type, ngx_flag_t store_messages, ngx_pool_t *temp_pool);

--- a/src/ngx_http_push_stream_module_publisher.c
+++ b/src/ngx_http_push_stream_module_publisher.c
@@ -43,7 +43,11 @@ ngx_http_push_stream_publisher_handler(ngx_http_request_t *r)
 
 
     if (cf->allowed_origins != NULL) {
-        ngx_http_push_stream_complex_value(r, cf->allowed_origins, &vv_allowed_origins);
+        if (ngx_http_push_stream_complex_value(r, cf->allowed_origins, &vv_allowed_origins) != NGX_OK)
+		{
+        	ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "push stream module: failed to push complex value cf->allowed_origin");
+		return NGX_ERROR;
+		}
     }
 
     if (vv_allowed_origins.len > 0) {

--- a/src/ngx_http_push_stream_module_subscriber.c
+++ b/src/ngx_http_push_stream_module_subscriber.c
@@ -651,7 +651,11 @@ ngx_http_push_stream_get_padding_by_user_agent(ngx_http_request_t *r)
     ngx_str_t                                       vv_user_agent = ngx_null_string;
 
     if (cf->user_agent != NULL) {
-        ngx_http_push_stream_complex_value(r, cf->user_agent, &vv_user_agent);
+        if (ngx_http_push_stream_complex_value(r, cf->user_agent, &vv_user_agent) != NGX_OK)
+		{
+       		ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "push stream module: failed to push complex value cf->user_agent");
+		return NULL;
+		}	
     } else if (r->headers_in.user_agent != NULL) {
         vv_user_agent = r->headers_in.user_agent->value;
     }

--- a/src/ngx_http_push_stream_module_utils.c
+++ b/src/ngx_http_push_stream_module_utils.c
@@ -1884,17 +1884,17 @@ ngx_http_push_stream_get_last_received_message_values(ngx_http_request_t *r, tim
     }
 
     if (cf->last_event_id != NULL) {
-        if (ngx_http_push_stream_complex_value(r, cf->last_event_id, &vv_event_id) == NGX_OK) 
-		{
+        if (ngx_http_push_stream_complex_value(r, cf->last_event_id, &vv_event_id) == NGX_OK) {
 		if (vv_event_id.len) {
 		    *last_event_id = ngx_http_push_stream_create_str(ctx->temp_pool, vv_event_id.len);
 		    ngx_memcpy(((ngx_str_t *)*last_event_id)->data, vv_event_id.data, vv_event_id.len);
 		}
-	else 	
-		{
-        	ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "push stream module: failed to push stream complex value cf->last_event_id");
+		else {
+        	     ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "push stream module: failed to push stream complex value cf->last_event_id");
         	}
-    } else {
+    	}
+    }
+    else {
         *last_event_id = ngx_http_push_stream_get_header(r, &NGX_HTTP_PUSH_STREAM_HEADER_LAST_EVENT_ID);
     }
 


### PR DESCRIPTION
Hello! I was analyzing your module with **Svace SAST tool** and found vulnerability in ngx_http_push_stream_complex_value. The problem is ngx_http_complex_value function return value not being checked:

https://github.com/wandenberg/nginx-push-stream-module/blob/b1c1a088e9c747e24c100146fd745718e72bb778/src/ngx_http_push_stream_module_utils.c#L2122

But it should because of this part in ngx_http_complex_value:

https://github.com/nginx/nginx/blob/d31305653701bd99e8e5e6aa48094599a08f9f12/src/http/ngx_http_script.c#L79-L90
![изображение](https://github.com/user-attachments/assets/f200b386-793e-4764-af47-4d807b347c2f)

If allocation with ngx_palloc fails and returns NULL, value->data will be NULL but value->len won`t be zero. So when we come back from ngx_http_complex_value and step into ngx_http_push_stream_unescape_uri we will see that this part of code relies only on value->len not being zero:
https://github.com/wandenberg/nginx-push-stream-module/blob/b1c1a088e9c747e24c100146fd745718e72bb778/src/ngx_http_push_stream_module_utils.c#L2132-L2140

But as I mentioned above there can be a situation where value->len is not zero but value->data is NULL. Dst and src values both became NULL and go as arguments into ngx_unescape_uri function which neither checks them being NULL. 
https://github.com/nginx/nginx/blob/d31305653701bd99e8e5e6aa48094599a08f9f12/src/core/ngx_string.c#L1676-L1694
![изображение](https://github.com/user-attachments/assets/158fc5b7-3cd3-413a-9d04-e0bfdf1eae64)

So there will be a crash right here, where "s" is dereferenced.

I've changed  ngx_http_push_stream_complex_value in my pull request and made it return either NGX_ERROR or NGX_OK and have changed all places where it is being called also added logging where necessary. 

It compiles well, haven't seen any trouble, and it passes 399 tests. It has two failures, one of them is "Measure Memory should check subscribers system size" **(./spec/mix/measure_memory_spec.rb:105)** but it happens also with current github version. 

The only thing I found uniquely troublesome with my version is "Publisher Messages should expose message size through message template" test failed **(./spec/publisher/publish_messages_spec.rb:333)**. It happens only when I test with my commits but I`m lacking experience with this module to trace it properly so my pull request should be modified a bit I guess. But I have no idea where. 

_Found by Linux Verification Center (linuxtesting.org) with SVACE._  



